### PR TITLE
Remove the extra "B" for bugfix.

### DIFF
--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -1,4 +1,4 @@
-B# (C) Copyright 2018 UCAR.
+# (C) Copyright 2018 UCAR.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.


### PR DESCRIPTION
Remove the letter "B" from the file: `cmake/compiler_flags_Intel_Fortran.cmake` for a bugfix. 