### PR TITLE
Feature/lnd ens

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,4 +37,3 @@ cmake --build . --target install
 cd .. 
 
 exit 0
-

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -72,12 +72,12 @@
     open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit, iomsg=ioerrmsg)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
     close (lunit)
-    if (ierr /= 0) then
-        write(6,*) trim(ioerrmsg)         
-        call mpi_abort(mpi_comm_world, 10)
-    end if
+    ! if (ierr /= 0) then
+    !     write(6,*) trim(ioerrmsg)         
+    !     call mpi_abort(mpi_comm_world, 10)
+    ! end if
     if (myrank==0) then
-    !    write (6, noahmp_snow)
+       write (6, noahmp_snow)
         print*, 'ens_size ', ens_size, ' ntiles ', ntiles
     end if
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -51,8 +51,8 @@
     print*,"starting apply_incr_noahmp_snow program on rank ", my_global_rank
 
     ! SET NAMELIST DEFAULTS
-    rst_path = '.'
-    inc_path = '.'
+    rst_path = './'
+    inc_path = './'
     ntiles = 6
     ens_size = 1
     ! READ NAMELIST 
@@ -89,13 +89,13 @@
 
         write(ens_str, '(I3.3)') (ie+1)
 
-!TODO: we might just keep the default for ens_size=1
-        if(ens_size.eq.1) then 
-            rst_path_full = trim(rst_path)//"/mem000/"
-            inc_path_full = trim(inc_path)//"/mem000/"
-        else
+!TBCL: keep the default for ens_size=1
+        if(ens_size > 1) then 
             rst_path_full = trim(rst_path)//"/mem"//ens_str//"/"
             inc_path_full = trim(inc_path)//"/mem"//ens_str//"/"
+        else
+            rst_path_full = trim(rst_path)      !//"/mem000/"
+            inc_path_full = trim(inc_path)      !//"/mem000/"
         endif
 
         print*

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -202,7 +202,12 @@
             deallocate(snow_depth_back) !
         endif
 
+        print*
+        print*, "finisheed loop proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
+
     enddo
+    
+    print*, "finisheed apply_incr_noahmp_snow on proc ", myrank
     call mpi_finalize(ierr)
 
  contains 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -77,11 +77,11 @@
         write(6,*) trim(ioerrmsg)         
         call mpi_abort(mpi_comm_world, 10)
     end if
-    ! uncommented this because it helped catch a namelist error
-    if (myrank==0) then
-       write (6, noahmp_snow)
-    !    print*, 'ens_size ', ens_size, ' ntiles ', ntiles
-    end if
+    ! uncommenting this may help catch a namelist error
+    ! if (myrank==0) then
+    !    write (6, noahmp_snow)
+    ! !    print*, 'ens_size ', ens_size, ' ntiles ', ntiles
+    ! end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID
     if (frac_grid) then 
@@ -112,7 +112,7 @@
         endif
 
         print*
-        print*, "apply_incr_noahmp_snow on proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
+        print*, "Proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
 
         ! GET MAPPING INDEX (see subroutine comments re: source of land/sea mask)
 
@@ -185,8 +185,8 @@
                     frac_grid, tile2vector) 
 
         ! CLOSE RESTART FILE 
-        print*
-        print*,"apply_incr_noahmp_snow, closing restart on proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
+        ! print*
+        ! print*,"apply_incr_noahmp_snow, closing restart on proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
         ierr = nf90_close(ncid)
         call netcdf_err( ierr, "closing restart file "//trim(restart_file) )
         
@@ -211,12 +211,12 @@
             deallocate(snow_depth_back) !
         endif
 
-        print*
-        print*, "finisheed loop proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
+        ! print*
+        ! print*, "finisheed loop proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
 
     enddo
 
-    print*, "finisheed apply_incr_noahmp_snow on proc ", myrank
+    print*, "Finisheed on proc ", myrank
     call mpi_finalize(ierr)
 
  contains 
@@ -299,7 +299,7 @@
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    write (6, *) 'calculate mapping from land mask in ', trim(restart_file)
+    ! write (6, *) 'calculate mapping from land mask in ', trim(restart_file)
 
     ierr=nf90_open(trim(restart_file),nf90_write,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(restart_file) )
@@ -406,7 +406,7 @@ end subroutine get_fv3_mapping
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    write (6, *) 'opening ', trim(restart_file)
+    ! write (6, *) 'opening ', trim(restart_file)
 
     ierr=nf90_open(trim(restart_file),nf90_write,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(restart_file) )
@@ -506,7 +506,7 @@ end subroutine read_fv3_restart
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    write (6, *) 'opening ', trim(filename)
+    ! write (6, *) 'opening ', trim(filename)
 
     ierr=nf90_open(trim(filename),nf90_nowrite,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(filename) )
@@ -527,7 +527,7 @@ end subroutine read_fv3_restart
                         'land_frac  ', grid_state%land_frac)
 
     ! close file 
-    write (6, *) 'closing ', trim(filename)
+    ! write (6, *) 'closing ', trim(filename)
 
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(filename) )
@@ -574,7 +574,7 @@ end subroutine read_fv3_orog
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    write (6, *) 'opening ', trim(incr_file)
+    ! write (6, *) 'opening ', trim(incr_file)
 
     ierr=nf90_open(trim(incr_file),nf90_nowrite,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(incr_file) )
@@ -595,7 +595,7 @@ end subroutine read_fv3_orog
                         control_var, increment)
 
     ! close file 
-    write (6, *) 'closing ', trim(incr_file)
+    ! write (6, *) 'closing ', trim(incr_file)
 
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(incr_file) )

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -174,7 +174,7 @@
         ierr = nf90_close(ncid)
         
         ! Deallocate. These are required incase a single process loops through multiple tiles     
-        if allocated(tile2vector) deallocate(tile2vector)   
+        if (allocated(tile2vector)) deallocate(tile2vector)   
         deallocate(noahmp_state%swe) ! values over land only
         deallocate(noahmp_state%snow_depth) ! values over land only 
         deallocate(noahmp_state%active_snow_layers) 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -51,7 +51,7 @@
     call mpi_comm_rank(mpi_comm_world, myrank, ierr)
 
     print*
-    print*,"starting apply_incr_noahmp_snow program on rank ", myrank
+    print*,"starting apply_incr_noahmp_snow program on rank ", myrank, ' of ', nprocs, ' procs'
 
     ! SET NAMELIST DEFAULTS
     rst_path = './'
@@ -69,9 +69,10 @@
 
     open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
-    !if (myrank==0) then
+    if (myrank==0) then
     !    write (6, noahmp_snow)
-    !end if
+        print*, 'ens_size ', ens_size, ' num_tiles ', num_tiles
+    end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID
     if (frac_grid) then 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -173,7 +173,8 @@
         print*,"closing restart, apply_incr_noahmp_snow ensemble member ", ie+1, " tile ", myrank+1, " on proc ", my_global_rank
         ierr = nf90_close(ncid)
         
-        ! Deallocate. These are required incase a single process loops through multiple tiles        
+        ! Deallocate. These are required incase a single process loops through multiple tiles     
+        if allocated(tile2vector) deallocate(tile2vector)   
         deallocate(noahmp_state%swe) ! values over land only
         deallocate(noahmp_state%snow_depth) ! values over land only 
         deallocate(noahmp_state%active_snow_layers) 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -43,6 +43,7 @@
 
  character(len=512) :: restart_file
  character(len=1)   :: tilech
+ character(len=512) :: ioerrmsg
 
  namelist /noahmp_snow/ date_str, hour_str, res, frac_grid, rst_path, inc_path, orog_path, otype, ntiles, ens_size
 !
@@ -58,6 +59,7 @@
     inc_path = './'
     ntiles = 6
     ens_size = 1
+
     ! READ NAMELIST 
 
     inquire (file='apply_incr_nml', exist=file_exists) 
@@ -67,8 +69,13 @@
         call mpi_abort(mpi_comm_world, 10)
     end if
 
-    open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit)
+    open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit, iomsg=ioerrmsg)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
+    close (nlunit)
+    if (ierr /= 0) then
+        write(6,*) trim(ioerrmsg)         
+        call mpi_abort(mpi_comm_world, 10)
+    end if
     if (myrank==0) then
     !    write (6, noahmp_snow)
         print*, 'ens_size ', ens_size, ' ntiles ', ntiles

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -21,7 +21,7 @@
  double precision, allocatable :: swe_back(:) 
  double precision, allocatable :: snow_depth_back(:) 
 
- integer :: ierr, nprocs, myrank, my_global_rank, lunit, ncid, n, ntiles, ens_size
+ integer :: ierr, nprocs, myrank, my_global_rank, lunit, ncid, n
  integer :: ntiles, ens_size, ie 
  character(len=3) :: ens_str
  logical :: file_exists
@@ -84,8 +84,8 @@
     endif
 
     do irank=my_global_rank, ntiles*ens_size, nprocs
-        ie = irank/ntiles    !/ Np_til  ! sub array length per proc
-        myrank = MOD(irank, ntiles)  !LENSFC - N_sA * Np_til ! extra grid cells
+        ie = irank/ntiles    
+        myrank = MOD(irank, ntiles)  
 
         write(ens_str, '(I3.3)') (ie+1)
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -71,7 +71,7 @@
 
     open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit, iomsg=ioerrmsg)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
-    close (nlunit)
+    close (lunit)
     if (ierr /= 0) then
         write(6,*) trim(ioerrmsg)         
         call mpi_abort(mpi_comm_world, 10)

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -72,13 +72,15 @@
     open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit, iomsg=ioerrmsg)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
     close (lunit)
-    ! if (ierr /= 0) then
-    !     write(6,*) trim(ioerrmsg)         
-    !     call mpi_abort(mpi_comm_world, 10)
-    ! end if
+    if (ierr /= 0) then
+        print*, "Error code from namelist read", ierr
+        write(6,*) trim(ioerrmsg)         
+        call mpi_abort(mpi_comm_world, 10)
+    end if
+    ! uncommented this because it helped catch a namelist error
     if (myrank==0) then
        write (6, noahmp_snow)
-        print*, 'ens_size ', ens_size, ' ntiles ', ntiles
+    !    print*, 'ens_size ', ens_size, ' ntiles ', ntiles
     end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -55,6 +55,7 @@
     print*,"starting apply_incr_noahmp_snow program on rank ", myrank, ' of ', nprocs, ' procs'
 
     ! SET NAMELIST DEFAULTS
+    frac_grid = .false.
     rst_path = './'
     inc_path = './'
     ntiles = 6

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -21,7 +21,7 @@
  double precision, allocatable :: swe_back(:) 
  double precision, allocatable :: snow_depth_back(:) 
 
- integer :: ierr, nprocs, myrank, my_global_rank, lunit, ncid, n
+ integer :: ierr, irank, nprocs, myrank, my_global_rank, lunit, ncid, n
  integer :: ntiles, ens_size, ie 
  character(len=3) :: ens_str
  logical :: file_exists
@@ -99,7 +99,7 @@
         endif
 
         print*
-        print*,"apply_incr_noahmp_snow ensemble member ", ie+1, " tile ", myrank+1, " on proc " my_global_rank
+        print*,"apply_incr_noahmp_snow ensemble member ", ie+1, " tile ", myrank+1, " on proc ", my_global_rank
 
         ! GET MAPPING INDEX (see subroutine comments re: source of land/sea mask)
 
@@ -170,7 +170,7 @@
 
         ! CLOSE RESTART FILE 
         print*
-        print*,"closing restart, apply_incr_noahmp_snow ensemble member ", ie+1, " tile ", myrank+1, " on proc " my_global_rank
+        print*,"closing restart, apply_incr_noahmp_snow ensemble member ", ie+1, " tile ", myrank+1, " on proc ", my_global_rank
         ierr = nf90_close(ncid)
         
         ! Deallocate. These are required incase a single process loops through multiple tiles        

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -71,7 +71,7 @@
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
     if (myrank==0) then
     !    write (6, noahmp_snow)
-        print*, 'ens_size ', ens_size, ' num_tiles ', num_tiles
+        print*, 'ens_size ', ens_size, ' ntiles ', ntiles
     end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID
@@ -206,7 +206,7 @@
         print*, "finisheed loop proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
 
     enddo
-    
+
     print*, "finisheed apply_incr_noahmp_snow on proc ", myrank
     call mpi_finalize(ierr)
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -51,7 +51,6 @@
     call mpi_comm_size(mpi_comm_world, nprocs, ierr)
     call mpi_comm_rank(mpi_comm_world, myrank, ierr)
 
-    print*
     print*,"starting apply_incr_noahmp_snow program on rank ", myrank, ' of ', nprocs, ' procs'
 
     ! SET NAMELIST DEFAULTS
@@ -62,7 +61,6 @@
     ens_size = 1
 
     ! READ NAMELIST 
-
     inquire (file='apply_incr_nml', exist=file_exists) 
 
     if (.not. file_exists) then
@@ -78,11 +76,6 @@
         write(6,*) trim(ioerrmsg)         
         call mpi_abort(mpi_comm_world, 10)
     end if
-    ! uncommenting this may help catch a namelist error
-    ! if (myrank==0) then
-    !    write (6, noahmp_snow)
-    ! !    print*, 'ens_size ', ens_size, ' ntiles ', ntiles
-    ! end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID
     if (frac_grid) then 
@@ -108,19 +101,16 @@
             rst_path_full = trim(rst_path)//"/mem"//ens_str//"/"
             inc_path_full = trim(inc_path)//"/mem"//ens_str//"/"
         else
-            rst_path_full = trim(rst_path)      !//"/mem000/"
-            inc_path_full = trim(inc_path)      !//"/mem000/"
+            rst_path_full = trim(rst_path)      
+            inc_path_full = trim(inc_path)      
         endif
 
-        print*
         print*, "Proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
 
         ! GET MAPPING INDEX (see subroutine comments re: source of land/sea mask)
-
         call get_fv3_mapping(myrank, ens_mem, tile_num, rst_path_full, date_str, hour_str, res, len_land_vec, frac_grid, tile2vector)
     
-        ! SET-UP THE NOAH-MP STATE  AND INCREMENT
-        
+        ! SET-UP THE NOAH-MP STATE  AND INCREMENT        
         ! The allocations are inside the loop because different ensemble members could have different len_land_vec
         allocate(noahmp_state%swe                (len_land_vec)) ! values over land only
         allocate(noahmp_state%snow_depth         (len_land_vec)) ! values over land only 
@@ -145,11 +135,10 @@
         write(tilech, '(i1.1)') (tile_num)
         restart_file = trim(rst_path_full)//"/"//date_str//"."//hour_str//"0000.sfc_data.tile"//tilech//".nc"
 
-        call   read_fv3_restart(trim(restart_file), res, ncid, &          !tile_num, rst_path_full, date_str, hour_str, 
+        call   read_fv3_restart(trim(restart_file), res, ncid, &         
                     len_land_vec, tile2vector, frac_grid, noahmp_state, grid_state)
 
         ! READ SNOW DEPTH INCREMENT
-
         call   read_fv3_increment(tile_num, inc_path_full, date_str, hour_str, res, &
                     len_land_vec, tile2vector, noahmp_state%name_snow_depth, increment)
     
@@ -159,12 +148,10 @@
         endif 
 
         ! ADJUST THE SNOW STATES OVER LAND
-
-!TBCL: return and check error code from this call (for now assume it is well handled inside function)
+!TODO: return and check error code from this call (for now assume it is well handled inside function)
         call UpdateAllLayers(len_land_vec, increment, noahmp_state)
 
         ! IF FRAC GRID, ADJUST SNOW STATES OVER GRID CELL
-
         if (frac_grid) then
 
             ! get the land frac 
@@ -181,13 +168,10 @@
         endif
 
         ! WRITE OUT ADJUSTED RESTART
-
         call   write_fv3_restart(trim(restart_file), noahmp_state, grid_state, res, ncid, len_land_vec, & 
                     frac_grid, tile2vector) 
 
         ! CLOSE RESTART FILE 
-        ! print*
-        ! print*,"apply_incr_noahmp_snow, closing restart on proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
         ierr = nf90_close(ncid)
         call netcdf_err( ierr, "closing restart file "//trim(restart_file) )
         
@@ -212,19 +196,15 @@
             deallocate(snow_depth_back) !
         endif
 
-        ! print*
-        ! print*, "finisheed loop proc ", myrank, " ensemble member ", ens_mem, " tile ", tile_num
-
     enddo
 
-    print*, "Finisheed on proc ", myrank
+    print*, "apply_incr_noahmp_snow finisheed on proc ", myrank
     call mpi_finalize(ierr)
 
  contains 
 
 !--------------------------------------------------------------
-! if at netcdf call returns an error, print out a message
-! and stop processing.
+! if at netcdf call returns an error, print out a message and stop processing.
 !--------------------------------------------------------------
  subroutine netcdf_err( err, string )
 
@@ -300,8 +280,6 @@
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    ! write (6, *) 'calculate mapping from land mask in ', trim(restart_file)
-
     ierr=nf90_open(trim(restart_file),nf90_write,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(restart_file) )
 
@@ -373,7 +351,7 @@ end subroutine get_fv3_mapping
 ! open fv3 restart, and read in required variables
 ! file is opened as read/write and remains open
 !--------------------------------------------------------------
- subroutine read_fv3_restart(restart_file, res, ncid, &                      !tile_num, rst_path, date_str, hour_str, 
+ subroutine read_fv3_restart(restart_file, res, ncid, & 
                 len_land_vec,tile2vector, frac_grid, noahmp_state, grid_state)
 
  implicit none 
@@ -382,8 +360,6 @@ end subroutine get_fv3_mapping
 
  integer, intent(in) :: res, len_land_vec   !tile_num, 
  character(len=*), intent(in) :: restart_file  !rst_path
-!  character(len=8), intent(in) :: date_str 
-!  character(len=2), intent(in) :: hour_str 
  integer, intent(in) :: tile2vector(len_land_vec,2)
  logical, intent(in) :: frac_grid
 
@@ -391,14 +367,11 @@ end subroutine get_fv3_mapping
  type(noahmp_type), intent(inout)  :: noahmp_state
  type(grid_type), intent(inout)  :: grid_state
 
-!  character(len=512) :: restart_file
-!  character(len=1) :: rankch
  logical :: file_exists
  integer :: ierr, id_dim, fres
  integer :: nn
 
     ! OPEN FILE
-
     inquire(file=trim(restart_file), exist=file_exists)
 
     if (.not. file_exists) then
@@ -406,8 +379,6 @@ end subroutine get_fv3_mapping
                     trim(restart_file) , ' exiting'
             call mpi_abort(mpi_comm_world, 10) 
     endif
-
-    ! write (6, *) 'opening ', trim(restart_file)
 
     ierr=nf90_open(trim(restart_file),nf90_write,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(restart_file) )
@@ -507,8 +478,6 @@ end subroutine read_fv3_restart
             call mpi_abort(mpi_comm_world, 10) 
     endif
 
-    ! write (6, *) 'opening ', trim(filename)
-
     ierr=nf90_open(trim(filename),nf90_nowrite,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(filename) )
 
@@ -528,8 +497,6 @@ end subroutine read_fv3_restart
                         'land_frac  ', grid_state%land_frac)
 
     ! close file 
-    ! write (6, *) 'closing ', trim(filename)
-
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(filename) )
 
@@ -561,8 +528,6 @@ end subroutine read_fv3_orog
  integer :: id_dim, id_var, fres, ncid
  integer :: nn
 
-
- 
     ! OPEN FILE
     write(rankch, '(i1.1)') (tile_num)
     incr_file = trim(inc_path)//"/"//"snowinc."//date_str//"."//hour_str//"0000.sfc_data.tile"//rankch//".nc"
@@ -574,8 +539,6 @@ end subroutine read_fv3_orog
                     trim(incr_file) , ' exiting'
             call mpi_abort(mpi_comm_world, 10) 
     endif
-
-    ! write (6, *) 'opening ', trim(incr_file)
 
     ierr=nf90_open(trim(incr_file),nf90_nowrite,ncid)
     call netcdf_err(ierr, 'opening file: '//trim(incr_file) )
@@ -595,9 +558,6 @@ end subroutine read_fv3_orog
     call read_nc_var2D(ncid, trim(incr_file), len_land_vec, res, tile2vector, 0, & 
                         control_var, increment)
 
-    ! close file 
-    ! write (6, *) 'closing ', trim(incr_file)
-
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(incr_file) )
 
@@ -607,7 +567,6 @@ end subroutine  read_fv3_increment
 ! Subroutine to read in a 2D variable from netcdf file, 
 ! and save to noahmp vector
 !--------------------------------------------------------
-
 subroutine read_nc_var2D(ncid, file_name, len_land_vec, res, tile2vector, in3D_vdim,  & 
                          var_name, data_vec)
 
@@ -646,7 +605,6 @@ end subroutine read_nc_var2D
 ! Subroutine to read in a 3D variable from netcdf file, 
 ! and save to noahmp vector
 !--------------------------------------------------------
-
 subroutine read_nc_var3D(ncid, file_name, len_land_vec, res, vdim,  & 
                 tile2vector, var_name, data_vec)
 
@@ -684,7 +642,6 @@ end subroutine read_nc_var3D
  type(grid_type), intent(in) :: grid_state
  logical, intent(in) :: frac_grid
  integer, intent(in) :: tile2vector(len_land_vec,2)
-
  
    ! write swe over land (file name: sheleg, vert dim 1) 
     call write_nc_var2D(ncid, trim(file_name), len_land_vec, res, tile2vector, 0, & 
@@ -739,7 +696,6 @@ end subroutine read_nc_var3D
 !--------------------------------------------------------
 ! Subroutine to write a 2D variable to the netcdf file 
 !--------------------------------------------------------
-
 subroutine write_nc_var2D(ncid, file_name, len_land_vec, res, tile2vector,   & 
                 in3D_vdim, var_name, data_vec)
 
@@ -788,7 +744,6 @@ end subroutine write_nc_var2D
 !--------------------------------------------------------
 ! Subroutine to write a 3D variable to the netcdf file 
 !--------------------------------------------------------
-
 subroutine write_nc_var3D(ncid, file_name, len_land_vec, res, vdim, & 
                 tile2vector, var_name, data_vec)
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -46,7 +46,7 @@
  character(len=512) :: ioerrmsg
 
  namelist /noahmp_snow/ date_str, hour_str, res, frac_grid, rst_path, inc_path, orog_path, otype, ntiles, ens_size
-!
+
     call mpi_init(ierr)
     call mpi_comm_size(mpi_comm_world, nprocs, ierr)
     call mpi_comm_rank(mpi_comm_world, myrank, ierr)

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -39,7 +39,7 @@
 
  character(len=512) :: orog_path, rst_path_full, inc_path_full
  character(len=256) :: rst_path, inc_path
- character*20       :: otype ! orography filename stub. For atm only, oro_C${RES}, for atm/ocean oro_C${RES}.mx100
+ character(len=20)  :: otype ! orography filename stub. For atm only, oro_C${RES}, for atm/ocean oro_C${RES}.mx100
 
  character(len=512) :: restart_file
  character(len=1)   :: tilech


### PR DESCRIPTION
Revisions to the add_jedi_incr to run it with
- any number of MPI processes (instead of 6)
- an arbitrary number of tiles (regional grids can have only 1 tile)
with minimal/one change to the calling script (DA_update/do_landDA.sh). 
Other changes are diagnostic to help catch any input errors.

The only change to DA_update/do_landDA.sh sets frac_grid in apply_incr_nml as logical (frac_grid=.false.) instead of "YES/NO" 

The land-offline_workflow tests pass (tested with 6, 5, and 1 processes running apply_incr.exe)