### PR TITLE
add print debug

### DIFF
--- a/sorc/NoahMPdisag_module.f90
+++ b/sorc/NoahMPdisag_module.f90
@@ -26,7 +26,7 @@ module NoahMPdisag_module
 
 contains
 
-  subroutine UpdateAllLayers(vector_length, increment, noahmp, noincr_threshold, print_out_summary)
+  subroutine UpdateAllLayers(vector_length, increment, noahmp, noincr_threshold, print_out_summary, print_debug)
 
  ! intent(in)
   integer, intent(in)                :: vector_length
@@ -36,6 +36,7 @@ contains
   type(noahmp_type), intent(inout)   :: noahmp
   double precision, intent(in)       :: noincr_threshold
   logical, intent(in)                :: print_out_summary
+  logical, intent(in), optional      :: print_debug
 
   double precision       :: layer_density, swe_increment, liq_ratio, delta
   integer                :: iloc, ilayer, iinter, active_layers, vector_loc, pathway
@@ -43,6 +44,10 @@ contains
   double precision       :: partition_ratio, layer_depths(3), anal_snow_depth
   double precision       :: temp_soil_corr
   integer                :: count0, count1, count2, count3, count4, count5, count6, count7, count8
+  logical                :: print_debug_out
+
+  print_debug_out = .false.
+  if(present(print_debug)) print_debug_out = print_debug
 
   associate( &
                  swe => noahmp%swe                ,&
@@ -252,34 +257,35 @@ contains
         count0 = count0+1
     end if ! non-zero increment
     ! do some gross checks
-
-    if(abs(snow_soil_interface(iloc,7) - snow_soil_interface(iloc,3) + 2.d0) > 0.0000001) then
-      print*, "Depth of soil not 2m"
-      print*, "pathway", pathway
-      print*, snow_soil_interface(iloc,7), snow_soil_interface(iloc,3)
-!      stop
-    end if
-
-    if(active_snow_layers(iloc) < 0.0 .and. abs(snow_depth(iloc) + 1000.d0*snow_soil_interface(iloc,3)) > 0.0000001) then
-      print*, "snow_depth and snow_soil_interface inconsistent"
-      print*, "pathway", pathway
-      print*, active_snow_layers(iloc), snow_depth(iloc), snow_soil_interface(iloc,3)
-!      stop
-    end if
-
-    if( (abs(anal_snow_depth - snow_depth(iloc))   > 0.01) .and. (anal_snow_depth > 0.0001) .and. temperature_soil(iloc) <= 273.155 ) then
-! this condition will fail if snow added was limitted to 50mm to avoid layering issues
-      print*, "snow increment and updated model snow inconsistent"
-      print*, "pathway", pathway
-      print*, anal_snow_depth, snow_depth(iloc), temperature_soil(iloc)
-!      stop
-    end if
-
-    if(snow_depth(iloc) < 0.0 .or. snow_soil_interface(iloc,3) > 0.0 ) then
-      print*, "snow depth or interface has wrong sign"
-      print*, "pathway ", pathway
-      print*, snow_depth(iloc), snow_soil_interface(iloc,3)
-!      stop
+    if (print_debug_out) then 
+      if(abs(snow_soil_interface(iloc,7) - snow_soil_interface(iloc,3) + 2.d0) > 0.0000001) then
+        print*, "Depth of soil not 2m"
+        print*, "pathway", pathway
+        print*, snow_soil_interface(iloc,7), snow_soil_interface(iloc,3)
+  !      stop
+      end if
+  
+      if(active_snow_layers(iloc) < 0.0 .and. abs(snow_depth(iloc) + 1000.d0*snow_soil_interface(iloc,3)) > 0.0000001) then
+        print*, "snow_depth and snow_soil_interface inconsistent"
+        print*, "pathway", pathway
+        print*, active_snow_layers(iloc), snow_depth(iloc), snow_soil_interface(iloc,3)
+  !      stop
+      end if
+  
+      if( (abs(anal_snow_depth - snow_depth(iloc))   > 0.01) .and. (anal_snow_depth > 0.0001) .and. temperature_soil(iloc) <= 273.155 ) then
+  ! this condition will fail if snow added was limitted to 50mm to avoid layering issues
+        print*, "snow increment and updated model snow inconsistent"
+        print*, "pathway", pathway
+        print*, anal_snow_depth, snow_depth(iloc), temperature_soil(iloc)
+  !      stop
+      end if
+  
+      if(snow_depth(iloc) < 0.0 .or. snow_soil_interface(iloc,3) > 0.0 ) then
+        print*, "snow depth or interface has wrong sign"
+        print*, "pathway ", pathway
+        print*, snow_depth(iloc), snow_soil_interface(iloc,3)
+  !      stop
+      end if
     end if
 
   end do

--- a/sorc/NoahMPdisag_module.f90
+++ b/sorc/NoahMPdisag_module.f90
@@ -256,34 +256,34 @@ contains
     else
         count0 = count0+1
     end if ! non-zero increment
-    ! do some gross checks
-    if (print_debug_out) then 
-      if(abs(snow_soil_interface(iloc,7) - snow_soil_interface(iloc,3) + 2.d0) > 0.0000001) then
-        print*, "Depth of soil not 2m"
-        print*, "pathway", pathway
-        print*, snow_soil_interface(iloc,7), snow_soil_interface(iloc,3)
-  !      stop
-      end if
-  
-      if(active_snow_layers(iloc) < 0.0 .and. abs(snow_depth(iloc) + 1000.d0*snow_soil_interface(iloc,3)) > 0.0000001) then
-        print*, "snow_depth and snow_soil_interface inconsistent"
-        print*, "pathway", pathway
-        print*, active_snow_layers(iloc), snow_depth(iloc), snow_soil_interface(iloc,3)
-  !      stop
-      end if
-  
+    ! do some gross checks 
+    if(abs(snow_soil_interface(iloc,7) - snow_soil_interface(iloc,3) + 2.d0) > 0.0000001) then
+      print*, "Depth of soil not 2m"
+      print*, "pathway", pathway
+      print*, snow_soil_interface(iloc,7), snow_soil_interface(iloc,3)
+!      stop
+    end if
+
+    if(active_snow_layers(iloc) < 0.0 .and. abs(snow_depth(iloc) + 1000.d0*snow_soil_interface(iloc,3)) > 0.0000001) then
+      print*, "snow_depth and snow_soil_interface inconsistent"
+      print*, "pathway", pathway
+      print*, active_snow_layers(iloc), snow_depth(iloc), snow_soil_interface(iloc,3)
+!      stop
+    end if
+
+    if(snow_depth(iloc) < 0.0 .or. snow_soil_interface(iloc,3) > 0.0 ) then
+      print*, "snow depth or interface has wrong sign"
+      print*, "pathway ", pathway
+      print*, snow_depth(iloc), snow_soil_interface(iloc,3)
+!      stop
+    end if
+
+    if (print_debug_out) then
       if( (abs(anal_snow_depth - snow_depth(iloc))   > 0.01) .and. (anal_snow_depth > 0.0001) .and. temperature_soil(iloc) <= 273.155 ) then
   ! this condition will fail if snow added was limitted to 50mm to avoid layering issues
         print*, "snow increment and updated model snow inconsistent"
         print*, "pathway", pathway
         print*, anal_snow_depth, snow_depth(iloc), temperature_soil(iloc)
-  !      stop
-      end if
-  
-      if(snow_depth(iloc) < 0.0 .or. snow_soil_interface(iloc,3) > 0.0 ) then
-        print*, "snow depth or interface has wrong sign"
-        print*, "pathway ", pathway
-        print*, snow_depth(iloc), snow_soil_interface(iloc,3)
   !      stop
       end if
     end if

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -562,7 +562,7 @@ end subroutine read_fv3_orog
     ! read snow_depth (file name: snwdph, vert dim 1)
     call read_nc_var2D(ncid, trim(incr_file), len_land_vec, res, tile2vector, 0, & 
                         control_var, increment)
-    ! Truncate small increments if requested
+    ! Truncate increments if requested
     if (truncate) then
         do nn = 1, len_land_vec
             increment(nn) = dble(nint(increment(nn) * 1.0d7)) / 1.0d7

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -78,10 +78,15 @@
     open (action='read', file='apply_incr_nml', iostat=ierr, newunit=lunit, iomsg=ioerrmsg)
     read (nml=noahmp_snow, iostat=ierr, unit=lunit)
     close (lunit)
-    if (ierr /= 0) then
+888 if (ierr /= 0) then
         print*, "Error code from namelist read", ierr
         write(6,*) trim(ioerrmsg)         
         call mpi_abort(mpi_comm_world, 10)  
+    end if
+999 if (ierr /= 0) then
+        print*, "warning! one or more default namelist values will be used. 
+        print*, "Error code from namelist read", ierr    
+        write(6,*) trim(ioerrmsg) 
     end if
 
     ! SET VARIABLE NAMES FOR SNOW OVER LAND AND GRID

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -46,10 +46,10 @@
  character(len=512) :: ioerrmsg
 
  double precision   :: noincr_threshold
- logical            :: print_summary, print_debug
+ logical            :: print_summary, print_debug, truncate
 
  namelist /noahmp_snow/ date_str, hour_str, res, frac_grid, rst_path, inc_path, orog_path, otype, ntiles, ens_size, &
-                        noincr_threshold, print_summary, print_debug
+                        noincr_threshold, print_summary, print_debug, truncate
 
     call mpi_init(ierr)
     call mpi_comm_size(mpi_comm_world, nprocs, ierr)
@@ -66,6 +66,7 @@
     noincr_threshold = 999999999.9
     print_summary = .true.
     print_debug = .false.
+    truncate = .false.
 
     ! READ NAMELIST 
     inquire (file='apply_incr_nml', exist=file_exists) 
@@ -150,7 +151,7 @@
 
         ! READ SNOW DEPTH INCREMENT
         call   read_fv3_increment(tile_num, inc_path_full, date_str, hour_str, res, &
-                    len_land_vec, tile2vector, noahmp_state%name_snow_depth, increment)
+                    len_land_vec, tile2vector, noahmp_state%name_snow_depth, truncate, increment)
     
         if (frac_grid) then ! save background
             swe_back = noahmp_state%swe
@@ -515,7 +516,7 @@ end subroutine read_fv3_orog
 !  file format is same as restart file
 !--------------------------------------------------------------
  subroutine read_fv3_increment(tile_num, inc_path, date_str, hour_str, res, & 
-                len_land_vec,tile2vector, control_var, increment)
+                len_land_vec,tile2vector, control_var, truncate, increment)
 
  implicit none 
 
@@ -527,6 +528,7 @@ end subroutine read_fv3_orog
  character(len=2), intent(in) :: hour_str 
  integer, intent(in) :: tile2vector(len_land_vec,2)
  character(len=10), intent(in)  :: control_var
+ logical, intent(in) :: truncate
  double precision, intent(out) :: increment(len_land_vec)     ! snow depth increment
 
  character(len=512) :: incr_file
@@ -565,7 +567,12 @@ end subroutine read_fv3_orog
     ! read snow_depth (file name: snwdph, vert dim 1)
     call read_nc_var2D(ncid, trim(incr_file), len_land_vec, res, tile2vector, 0, & 
                         control_var, increment)
-
+    ! Truncate small increments if requested
+    if (truncate) then
+        do nn = 1, len_land_vec
+            if (abs(increment(nn)) < 1.0e-7) increment(nn) = 0.0d0
+        end do
+    end if
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(incr_file) )
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -46,10 +46,10 @@
  character(len=512) :: ioerrmsg
 
  double precision   :: noincr_threshold
- logical            :: print_summary
+ logical            :: print_summary, print_debug
 
  namelist /noahmp_snow/ date_str, hour_str, res, frac_grid, rst_path, inc_path, orog_path, otype, ntiles, ens_size, &
-                        noincr_threshold, print_summary
+                        noincr_threshold, print_summary, print_debug
 
     call mpi_init(ierr)
     call mpi_comm_size(mpi_comm_world, nprocs, ierr)
@@ -65,6 +65,7 @@
     ens_size = 1
     noincr_threshold = 999999999.9
     print_summary = .true.
+    print_debug = .false.
 
     ! READ NAMELIST 
     inquire (file='apply_incr_nml', exist=file_exists) 
@@ -153,7 +154,7 @@
 
         ! ADJUST THE SNOW STATES OVER LAND
 !TODO: return and check error code from this call (for now assume it is well handled inside function)
-        call UpdateAllLayers(len_land_vec, increment, noahmp_state, noincr_threshold, print_summary)
+        call UpdateAllLayers(len_land_vec, increment, noahmp_state, noincr_threshold, print_summary, print_debug)
 
         ! IF FRAC GRID, ADJUST SNOW STATES OVER GRID CELL
         if (frac_grid) then

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -567,7 +567,7 @@ end subroutine read_fv3_orog
     ! read snow_depth (file name: snwdph, vert dim 1)
     call read_nc_var2D(ncid, trim(incr_file), len_land_vec, res, tile2vector, 0, & 
                         control_var, increment)
-    ! Truncate small increments if requested
+    ! Truncate increments if requested
     if (truncate) then
         do nn = 1, len_land_vec
             increment(nn) = dble(nint(increment(nn) * 1.0d7)) / 1.0d7

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -1,4 +1,4 @@
- program apply_incr_noahmp_snow
+program apply_incr_noahmp_snow
 
  use netcdf
 
@@ -570,7 +570,7 @@ end subroutine read_fv3_orog
     ! Truncate small increments if requested
     if (truncate) then
         do nn = 1, len_land_vec
-            if (abs(increment(nn)) < 1.0e-7) increment(nn) = 0.0d0
+            increment(nn) = dble(nint(increment(nn) * 1.0d7)) / 1.0d7
         end do
     end if
     ierr=nf90_close(ncid)

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -174,9 +174,41 @@ program apply_incr_noahmp_snow
                                     grid_state%land_frac(n)* ( noahmp_state%swe(n) - swe_back(n)) 
                     grid_state%snow_depth(n) = grid_state%snow_depth(n) + & 
                                     grid_state%land_frac(n)* ( noahmp_state%snow_depth(n) - snow_depth_back(n)) 
-            enddo
+            
+               ! check for negative valus
+                if((grid_state%snow_depth(n) <=  0.0001) .or. (grid_state%swe(n) <=  0.0001)) then
+                  grid_state%snow_depth(n) = 0.0
+                  grid_state%swe(n) = 0.0
 
+                  noahmp_state%swe                (n)   = 0.0
+                  noahmp_state%snow_depth         (n)   = 0.0
+                  noahmp_state%active_snow_layers (n)   = 0.0
+                  noahmp_state%swe_previous       (n)   = 0.0
+                  noahmp_state%snow_soil_interface(n,:) = (/0.0,0.0,0.0,-0.1,-0.4,-1.0,-2.0/)
+                  noahmp_state%temperature_snow   (n,:) = 0.0
+                  noahmp_state%snow_ice_layer     (n,:) = 0.0
+                  noahmp_state%snow_liq_layer     (n,:) = 0.0
+                endif
+            enddo
         endif
+        
+        ! check for negative valus again
+        do n=1,len_land_vec
+          if((noahmp_state%snow_depth(n) <=  0.0001) .or. (noahmp_state%swe(n) <=  0.0001)) then 
+            noahmp_state%swe                (n)   = 0.0
+            noahmp_state%snow_depth         (n)   = 0.0
+            noahmp_state%active_snow_layers (n)   = 0.0
+            noahmp_state%swe_previous       (n)   = 0.0
+            noahmp_state%snow_soil_interface(n,:) = (/0.0,0.0,0.0,-0.1,-0.4,-1.0,-2.0/)
+            noahmp_state%temperature_snow   (n,:) = 0.0
+            noahmp_state%snow_ice_layer     (n,:) = 0.0
+            noahmp_state%snow_liq_layer     (n,:) = 0.0
+            if (frac_grid) then          
+              grid_state%snow_depth(n) = 0.0
+              grid_state%swe(n) = 0.0          
+            endif
+          endif
+        enddo
 
         ! WRITE OUT ADJUSTED RESTART
         call   write_fv3_restart(trim(restart_file), noahmp_state, grid_state, res, ncid, len_land_vec, & 
@@ -188,6 +220,7 @@ program apply_incr_noahmp_snow
         
         ! Deallocate. These are required incase a single process loops through multiple tiles with different mapping     
         if (allocated(tile2vector)) deallocate(tile2vector)   
+                
         deallocate(noahmp_state%swe) ! values over land only
         deallocate(noahmp_state%snow_depth) ! values over land only 
         deallocate(noahmp_state%active_snow_layers) 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -46,10 +46,10 @@
  character(len=512) :: ioerrmsg
 
  double precision   :: noincr_threshold
- logical            :: print_summary, print_debug
+ logical            :: print_summary, print_debug, truncate
 
  namelist /noahmp_snow/ date_str, hour_str, res, frac_grid, rst_path, inc_path, orog_path, otype, ntiles, ens_size, &
-                        noincr_threshold, print_summary, print_debug
+                        noincr_threshold, print_summary, print_debug, truncate
 
     call mpi_init(ierr)
     call mpi_comm_size(mpi_comm_world, nprocs, ierr)
@@ -66,6 +66,7 @@
     noincr_threshold = 999999999.9
     print_summary = .true.
     print_debug = .false.
+    truncate = .false.
 
     ! READ NAMELIST 
     inquire (file='apply_incr_nml', exist=file_exists) 
@@ -145,7 +146,7 @@
 
         ! READ SNOW DEPTH INCREMENT
         call   read_fv3_increment(tile_num, inc_path_full, date_str, hour_str, res, &
-                    len_land_vec, tile2vector, noahmp_state%name_snow_depth, increment)
+                    len_land_vec, tile2vector, noahmp_state%name_snow_depth, truncate, increment)
     
         if (frac_grid) then ! save background
             swe_back = noahmp_state%swe
@@ -510,7 +511,7 @@ end subroutine read_fv3_orog
 !  file format is same as restart file
 !--------------------------------------------------------------
  subroutine read_fv3_increment(tile_num, inc_path, date_str, hour_str, res, & 
-                len_land_vec,tile2vector, control_var, increment)
+                len_land_vec,tile2vector, control_var, truncate, increment)
 
  implicit none 
 
@@ -522,6 +523,7 @@ end subroutine read_fv3_orog
  character(len=2), intent(in) :: hour_str 
  integer, intent(in) :: tile2vector(len_land_vec,2)
  character(len=10), intent(in)  :: control_var
+ logical, intent(in) :: truncate
  double precision, intent(out) :: increment(len_land_vec)     ! snow depth increment
 
  character(len=512) :: incr_file
@@ -560,7 +562,12 @@ end subroutine read_fv3_orog
     ! read snow_depth (file name: snwdph, vert dim 1)
     call read_nc_var2D(ncid, trim(incr_file), len_land_vec, res, tile2vector, 0, & 
                         control_var, increment)
-
+    ! Truncate small increments if requested
+    if (truncate) then
+        do nn = 1, len_land_vec
+            if (abs(increment(nn)) < 1.0e-7) increment(nn) = 0.0d0
+        end do
+    end if
     ierr=nf90_close(ncid)
     call netcdf_err(ierr, 'closing file: '//trim(incr_file) )
 

--- a/sorc/apply_incr_noahmp_snow.f90
+++ b/sorc/apply_incr_noahmp_snow.f90
@@ -1,4 +1,4 @@
- program apply_incr_noahmp_snow
+program apply_incr_noahmp_snow
 
  use netcdf
 
@@ -565,7 +565,7 @@ end subroutine read_fv3_orog
     ! Truncate small increments if requested
     if (truncate) then
         do nn = 1, len_land_vec
-            if (abs(increment(nn)) < 1.0e-7) increment(nn) = 0.0d0
+            increment(nn) = dble(nint(increment(nn) * 1.0d7)) / 1.0d7
         end do
     end if
     ierr=nf90_close(ncid)


### PR DESCRIPTION
Add print debug as optional, while keeping the print summary always active. 

Print debug writes out warning when the analysis SND is capped at a prescribed value (50mm added on bare ground, +ve increment limited beyond a threshold background...). 